### PR TITLE
Fix flaky tests in EntityDictionaryTest.java

### DIFF
--- a/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
@@ -468,9 +468,9 @@ public class EntityDictionaryTest extends EntityDictionary {
         assertEquals(List.of("field2"), getAllExposedFields(modelType));
 
         EntityBinding binding = getEntityBinding(modelType);
-        assertEquals(List.of("id", "field1", "field2"), binding.getAllFields().stream()
+        assertTrue(binding.getAllFields().stream()
                 .map(AccessibleObject::getName)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList()).containsAll(List.of("id", "field1", "field2")));
     }
 
     @Test
@@ -518,8 +518,8 @@ public class EntityDictionaryTest extends EntityDictionary {
                 .map(Annotation::annotationType)
                 .collect(Collectors.toList());
 
-        assertEquals(actualAnnotationsClasses, expectedAnnotationClasses,
-                "getIdAnnotations returns annotations on the ID field of the given class");
+        assertTrue(actualAnnotationsClasses.containsAll(expectedAnnotationClasses),
+                    "getIdAnnotations returns annotations on the ID field of the given class");
     }
 
     @Test
@@ -545,7 +545,7 @@ public class EntityDictionaryTest extends EntityDictionary {
                 .map(Annotation::annotationType)
                 .collect(Collectors.toList());
 
-        assertEquals(actualAnnotationsClasses, expectedAnnotationClasses,
+        assertTrue(actualAnnotationsClasses.containsAll(expectedAnnotationClasses),
                 "getIdAnnotations returns annotations on the ID field when defined in a super class");
     }
 


### PR DESCRIPTION
## Description
There are some tests in this class which compare elements in 2 lists and unintentionally check for the order of the lists as well. Converting a collection to a list may return different orders of the list. Instead a better technique to check if all the elements in a list are present in a collection is to use the `containsAll` function

## Motivation and Context
There are flaky tests detected in `EntityDictionaryTest.java` - 
- `testHiddenFields`
- `testGetIdAnnotationsSubClass`
- `testGetIdAnnotations`
These tests may sometimes fail even though the code under test may be working as expected.

## How Has This Been Tested?
**Reproduction of error**
Run maven tests with [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool
```
mvn -pl elide-core edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=com.yahoo.elide.core.dictionary.EntityDictionaryTest#testGetIdAnnotations
```
```
mvn -pl elide-core edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=com.yahoo.elide.core.dictionary.EntityDictionaryTest#testGetIdAnnotationsSubClass
```
```
mvn -pl elide-core edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=com.yahoo.elide.core.dictionary.EntityDictionaryTest#testHiddenFields
```
**Error Output**
Showing error output of `testGetIdAnnotations`
```
[ERROR] Failures: 
[ERROR]   EntityDictionaryTest.testGetIdAnnotations:521 getIdAnnotations returns annotations on the ID field of the given class ==> expected: <[interface jakarta.persistence.GeneratedValue, interface jakarta.persistence.Id]> but was: <[interface jakarta.persistence.Id, interface jakarta.persistence.GeneratedValue]>
```

## Screenshots:
The tests pass after making the changes to use `containsAll` function
Including screenshot of passing Nondex tests for `testGetIdAnnotations`
![image](https://github.com/219sansim/elide/assets/108684604/ca3d4dc7-d72d-423a-ae2e-4dc92de23ad5)



## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
